### PR TITLE
Fallback to standard Adam optimizer

### DIFF
--- a/pretrain.py
+++ b/pretrain.py
@@ -16,7 +16,10 @@ import coolname
 import hydra
 import pydantic
 from omegaconf import DictConfig
-from adam_atan2 import AdamATan2
+try:
+    from adam_atan2 import AdamATan2
+except Exception:  # Fallback when custom backend is unavailable
+    from torch.optim import AdamW as AdamATan2
 
 from puzzle_dataset import PuzzleDataset, PuzzleDatasetConfig, PuzzleDatasetMetadata
 from utils.functions import load_model_class, get_model_source_path


### PR DESCRIPTION
## Summary
- handle missing `adam_atan2_backend` by falling back to `torch.optim.AdamW`

## Testing
- `pip install --prefer-binary --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt`
- `pip install numpy`
- `python pretrain.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68818f99b95c8320986515df6673fe18